### PR TITLE
Update to TensorFlow 2.18

### DIFF
--- a/common.py
+++ b/common.py
@@ -17,7 +17,7 @@ BASE_SIZE = 256
 NCSVS = 200
 NCATS = 340
 np.random.seed(seed=2018)
-tf.set_random_seed(seed=2018)
+tf.random.set_seed(seed=2018)
 
 
 def f2cat(filename: str) -> str:

--- a/common.py
+++ b/common.py
@@ -77,7 +77,7 @@ def draw_cv2(raw_strokes, size=256, lw=6, time_color=True):
 
 def image_generator_xd(size, batchsize, ks, lw=6, time_color=True):
     while True:
-        for k in np.random.permutation(ks):
+        for k in np.random.Generator.permutation(ks):
             filename = os.path.join(DP_DIR, 'train_k{}.csv.gz'.format(k))
             for df in pd.read_csv(filename, chunksize=batchsize):
                 df['drawing'] = df['drawing'].apply(ast.literal_eval)

--- a/main.py
+++ b/main.py
@@ -50,7 +50,7 @@ x = GlobalAveragePooling2D()(x)
 x = Dense(1024, activation='relu')(x)
 predictions = Dense(NCATS, activation='softmax')(x)
 model = Model(inputs=base_model.input, outputs=predictions)
-model.compile(optimizer=Adam(lr=1e-4, decay=1e-9), loss='categorical_crossentropy', metrics=[
+model.compile(optimizer=Adam(learning_rate=1e-4, decay=1e-9), loss='categorical_crossentropy', metrics=[
               categorical_crossentropy, categorical_accuracy, top_3_accuracy])
 
 # Load previous checkpoint


### PR DESCRIPTION
Several changes to the names and objects in TensorFlow 2 (which when quantified, are actually far and few between), completely break this repository when attempting to run it as of TensorFlow 2.18.0.

# **[tf.set_random_seed was deprecated and removed]**

Most notably, the Random system was completely overhauled.  TensorFlow encapsulated it into its own random class, which is instantiated by the runtime, and furthermore nests a Generator class which is intended to provide flexibility for a programmer to completely construct their own.

For this use case, however, it is simpler to just update to different default syntaxes, so that we are still using TensorFlow's default random, but to guarantee and future-proof it as more and more of the old random system gets deprecated.

This pull request updates the syntax related to random according to their warnings and notes in their documentation.  Doing so also fixes a crash as `tf.set_random_seed` is no longer defined.

# **[Adam's lr parameter was renamed to learning_rate]**

Another rather easy to miss change in the TensorFlow 2 suite; the parameter `lr` has been fully spelled out as the term `learning_rate`.  Seemingly, this has been adopted in all available model templates.

This pull request addresses this and updates the variable name.  This fixes a crash related to unrecognized parameters.
